### PR TITLE
devices: switch beryllium and potter to user build

### DIFF
--- a/arrow.devices
+++ b/arrow.devices
@@ -27,7 +27,7 @@
 #
 #
 - A6020 userdebug msm8916
-- beryllium userdebug sdm845
+- beryllium user sdm845
 - cheeseburger userdebug msm8998
 - chiron userdebug msm8998
 - clover userdebug sdm660
@@ -35,7 +35,7 @@
 - land userdebug msm8937
 - mido userdebug msm8953
 - polaris userdebug sdm845
-! potter userdebug msm8953
+! potter user msm8953
 - sanders userdebug msm8953
 - s2 userdebug msm8976
 - violet userdebug sm6150


### PR DESCRIPTION
Change-Id: I8127f45be9594eeff83765ebbe78d78fb588cf28