### PR TITLE
Export techpack/audio uapi headers of msm 4.14 kernel

### DIFF
--- a/build/soong/Android.bp
+++ b/build/soong/Android.bp
@@ -30,7 +30,11 @@ arrow_generator {
     cmd: "$(PATH_OVERRIDE_SOONG) $(KERNEL_MAKE_CMD) $(KERNEL_MAKE_FLAGS) -C $(TARGET_KERNEL_SOURCE) O=$(KERNEL_BUILD_OUT_PREFIX)$(genDir) ARCH=$(KERNEL_ARCH) $(KERNEL_CROSS_COMPILE) headers_install",
 
     // Directories that can be imported by a cc_* module generated_headers property
-    export_include_dirs: ["usr/include", "usr/techpack/audio/include"],
+    export_include_dirs: [
+        "usr/include",
+        "usr/include/audio/include/uapi",
+        "usr/techpack/audio/include"
+    ],
 
     // Sources for dependency tracking
     dep_root: "$(TARGET_KERNEL_SOURCE)",


### PR DESCRIPTION
 * With the techpack integration implementation of Google's msm-4.14
   kernel https://bit.ly/2WqiMFx (CAF didn't port this to their kernel
   thus suppose Google's port is the standard one), these headers are
   installed to include/audio/include/uapi.
 * This fixes building audio HAL with 4.14 kernel

Change-Id: I8283699470a7bcb31c771c9aa770a825b4e82519